### PR TITLE
Exchange_Feat_CRUD: #18 - 환율 서비스 CRUD 기능 구현

### DIFF
--- a/src/main/java/com/example/lazier/exchangeModule/controller/ExchangeController.java
+++ b/src/main/java/com/example/lazier/exchangeModule/controller/ExchangeController.java
@@ -1,0 +1,92 @@
+package com.example.lazier.exchangeModule.controller;
+
+import com.example.lazier.exchangeModule.dto.ExchangeDto;
+import com.example.lazier.exchangeModule.dto.PartialExchangeDto;
+import com.example.lazier.exchangeModule.service.ExchangeService;
+import com.example.lazier.exchangeModule.service.PartialExchangeService;
+import io.swagger.annotations.ApiOperation;
+import javax.servlet.http.HttpServletRequest;
+import javax.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/exchange")
+public class ExchangeController {
+
+    private final ExchangeService exchangeService;
+
+    private final PartialExchangeService partialExchangeService;
+
+    // 실시간 환율 정보 저장
+    @ApiOperation(value = "실시간 환율 정보를 DB에 저장")
+    @PostMapping
+    public ResponseEntity<?> addExchangeInfo(HttpServletRequest request,
+        @Valid ExchangeDto exchangeDto, PartialExchangeDto partialExchangeDto) {
+        String userId = request.getAttribute("userId").toString();
+        exchangeService.add(exchangeDto, userId);
+        partialExchangeService.partialAdd(partialExchangeDto, userId);
+
+        return new ResponseEntity<>(HttpStatus.CREATED);
+    }
+
+    // 메인 화면에서 볼 수 있는 환율 정보 조회
+    // (4가지 정보만 조회 가능 : 통화명, 매매기준율, 전일대비, 등락율) - 실제 적용
+    @ApiOperation(value = "메인화면 환율 창에서 환율 정보 조회(통화명, 매매기준율, 전일대비, 등락율)")
+    @GetMapping("/search")
+    public ResponseEntity<?> exchangePartialInfo(
+        HttpServletRequest request) {
+        String userId = request.getAttribute("userId").toString();
+        return new ResponseEntity<>(
+            partialExchangeService.getExchangePartialInfo(userId), HttpStatus.OK);
+    }
+
+    // 상세정보 조회 (특정 통화의 상세정보)
+    @ApiOperation(value = "특정 통화의 상세정보 조회")
+    @GetMapping("/search/{currencyName}")
+    public ResponseEntity<?> exchangeCurrencyNameDetail(
+        HttpServletRequest request, @PathVariable String currencyName) {
+        String userId = request.getAttribute("userId").toString();
+        return new ResponseEntity<>(
+            exchangeService.getExchangeCurrencyDetail(userId, currencyName), HttpStatus.OK);
+    }
+
+    // 상세정보 리스트 화면 (10가지 정보 모두 포함)
+    @ApiOperation(value = "국가별 환율 상세정보 조회")
+    @GetMapping("/list")
+    public ResponseEntity<?> exchangeList(HttpServletRequest request) {
+        String userId = request.getAttribute("userId").toString();
+        return new ResponseEntity<>(exchangeService.getExchangeList(userId), HttpStatus.OK);
+    }
+
+    // update
+    @ApiOperation(value = "환율정보 업데이트")
+    @PutMapping("/{userId}")
+    public ResponseEntity<?> updateExchange(
+        @RequestBody @PathVariable String userId,
+        ExchangeDto exchangeDto, PartialExchangeDto partialExchangeDto) {
+        exchangeService.updateRealTimeExchange(userId, exchangeDto);
+        partialExchangeService.updateRealTimePartialExchange(userId, partialExchangeDto);
+        return new ResponseEntity<>(HttpStatus.OK);
+    }
+
+    // delete
+    @ApiOperation(value = "환율정보 삭제")
+    @DeleteMapping( "/{userId}")
+    public ResponseEntity<?> deleteExchange(@PathVariable String userId) {
+        exchangeService.deleteExchange(userId);
+        partialExchangeService.deletePartialExchange(userId);
+        return new ResponseEntity<>(HttpStatus.OK);
+    }
+
+}

--- a/src/main/java/com/example/lazier/exchangeModule/dto/ExchangeDto.java
+++ b/src/main/java/com/example/lazier/exchangeModule/dto/ExchangeDto.java
@@ -1,0 +1,59 @@
+package com.example.lazier.exchangeModule.dto;
+
+import com.example.lazier.exchangeModule.persist.entity.Exchange;
+import java.util.ArrayList;
+import java.util.List;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class ExchangeDto {
+
+    private String userId;                  // 사용자명
+    private String currencyName;            // 통화명
+    private String tradingStandardRate;     // 매매기준율
+    private String comparedPreviousDay;     // 전일대비
+    private String fluctuationRate;         // 등락율
+    private String buyCash;                 // 현찰 살 때
+    private String sellCash;                // 현찰 팔 때
+    private String sendMoney;               // 송금 보낼 때
+    private String receiveMoney;            // 송금 받을 때
+    private String updateAt;                // 업데이트 날짜
+    private String round;                   // 고시회차
+
+    public static ExchangeDto to(Exchange exchange) {
+        return ExchangeDto.builder()
+                        .userId(exchange.getUserId())
+                        .currencyName(exchange.getCurrencyName())
+                        .tradingStandardRate(exchange.getTradingStandardRate())
+                        .comparedPreviousDay(exchange.getComparedPreviousDay())
+                        .fluctuationRate(exchange.getFluctuationRate())
+                        .buyCash(exchange.getBuyCash())
+                        .sellCash(exchange.getSellCash())
+                        .sendMoney(exchange.getSendMoney())
+                        .receiveMoney(exchange.getReceiveMoney())
+                        .updateAt(exchange.getUpdateAt())
+                        .round(exchange.getRound())
+                        .build();
+    }
+
+    public static List<ExchangeDto> from(List<Exchange> exchanges) {
+
+        if (exchanges == null) {
+            return null;
+        }
+
+        List<ExchangeDto> exchangeDtoList = new ArrayList<>();
+        for (Exchange x : exchanges) {
+            exchangeDtoList.add(ExchangeDto.to(x));
+        }
+
+        return exchangeDtoList;
+    }
+
+}

--- a/src/main/java/com/example/lazier/exchangeModule/persist/entity/Exchange.java
+++ b/src/main/java/com/example/lazier/exchangeModule/persist/entity/Exchange.java
@@ -1,0 +1,35 @@
+package com.example.lazier.exchangeModule.persist.entity;
+
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Entity(name = "EXCHANGE")
+@NoArgsConstructor
+@AllArgsConstructor
+@Getter
+@Setter
+@Builder
+public class Exchange {
+    @Id
+    @GeneratedValue(strategy = GenerationType.AUTO)
+    private Long id;
+    private String userId;
+    private String currencyName;            // 통화명
+    private String tradingStandardRate;     // 매매기준율
+    private String comparedPreviousDay;     // 전일대비
+    private String fluctuationRate;         // 등락율
+    private String buyCash;                 // 현찰 살 때
+    private String sellCash;                // 현찰 팔 때
+    private String sendMoney;               // 송금 보낼 때
+    private String receiveMoney;            // 송금 받을 때
+    private String updateAt;                // 업데이트 날짜
+    private String round;                   // 고시회차
+
+}

--- a/src/main/java/com/example/lazier/exchangeModule/persist/repository/ExchangeRepository.java
+++ b/src/main/java/com/example/lazier/exchangeModule/persist/repository/ExchangeRepository.java
@@ -1,0 +1,32 @@
+package com.example.lazier.exchangeModule.persist.repository;
+
+import com.example.lazier.exchangeModule.persist.entity.Exchange;
+import java.util.List;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.stereotype.Repository;
+import org.springframework.transaction.annotation.Transactional;
+
+@Repository
+public interface ExchangeRepository extends JpaRepository<Exchange, Long> {
+
+    /**
+     * 환율 정보 조회 (10개 통화의 10가지 정보) - 사용자 조건으로
+     */
+    Optional<List<Exchange>> findByUserId(String userId);
+
+    /**
+     * 통화별 상세정보 조회 (ex. 미국 통화명의 10가지 정보 조회) - 사용자, 통화명 조건으로
+     */
+    List<Exchange> findExchangesByUserIdAndCurrencyName(String userId, String currencyName);
+
+    /**
+     * 환율 정보 삭제
+     */
+    void deleteByUserId(String userId);
+
+
+
+}

--- a/src/main/java/com/example/lazier/exchangeModule/service/ExchangeService.java
+++ b/src/main/java/com/example/lazier/exchangeModule/service/ExchangeService.java
@@ -1,0 +1,33 @@
+package com.example.lazier.exchangeModule.service;
+
+import com.example.lazier.exchangeModule.dto.ExchangeDto;
+import java.util.List;
+
+public interface ExchangeService {
+
+    /**
+     * 환율정보 추가 (10가지 정보)
+     */
+    void add(ExchangeDto exchangeDto, String userId);
+
+    /**
+     * 환율정보 조회 (10개 통화의 4가지 정보) - 사용자 조건으로
+     */
+    List<ExchangeDto> getExchangeList(String userId);
+
+    /**
+     * 특정 통화의 환율 상세정보 조회 - 사용자, 통화명 조건으로
+     */
+    ExchangeDto getExchangeCurrencyDetail(String userId, String currencyName);
+
+    /**
+     * 사용자 정보 업데이트
+     */
+    void updateRealTimeExchange(String userId, ExchangeDto exchangedto);
+
+    /**
+     * 사용자 정보 삭제 (모듈 닫을 경우)
+     */
+    void deleteExchange(String userId);
+
+}

--- a/src/main/java/com/example/lazier/exchangeModule/service/ExchangeServiceImpl.java
+++ b/src/main/java/com/example/lazier/exchangeModule/service/ExchangeServiceImpl.java
@@ -1,0 +1,183 @@
+package com.example.lazier.exchangeModule.service;
+
+import com.example.lazier.exchangeModule.dto.ExchangeDto;
+import com.example.lazier.exchangeModule.exception.NotFoundExchangeException;
+import com.example.lazier.exchangeModule.exception.NotFoundUserIdException;
+import com.example.lazier.exchangeModule.persist.entity.Exchange;
+import com.example.lazier.exchangeModule.persist.repository.ExchangeRepository;
+import com.example.lazier.exchangeModule.scraper.ExchangeScraper;
+import java.util.List;
+import java.util.Optional;
+import javax.servlet.http.HttpServletRequest;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@RequiredArgsConstructor
+@Service
+public class ExchangeServiceImpl implements ExchangeService {
+
+    private final ExchangeRepository exchangeRepository;
+    private final ExchangeScraper scraper;
+
+    private final HttpServletRequest request;
+
+    // 환율 정보 추가 (10개 정보)
+    @Transactional
+    public void add(ExchangeDto exchangeDto, String userId) {
+        String exchangeString = scraper.scrap();
+
+        if (userId == null) {
+            throw new NotFoundUserIdException("사용자 ID를 찾을 수 없습니다.");
+        }
+
+        // 상세환율정보 화면 정보 추가 (10개)
+        for (int i = 0; i < 10; i++) {
+            String[] exchangeParse = exchangeString.split("\n");
+            String[] exchangeData = exchangeParse[i].split(" ");
+
+            String currencyName = exchangeData[0] + " " + exchangeData[1];
+            String tradingStandardRate = exchangeData[2];
+            String comparedToThePreviousDay = exchangeData[3] + " " + exchangeData[4];
+            String fluctuationRate = exchangeData[5];
+            String buyCash = exchangeData[6];
+            String sellCash = exchangeData[7];
+            String sendMoney = exchangeData[8];
+            String receiveMoney = exchangeData[9];
+            String updateAt = exchangeData[10];
+            String round = exchangeData[11] + " " + exchangeData[12];
+
+            ExchangeDto parameter = ExchangeDto.builder()
+                                            .userId(userId)
+                                            .currencyName(currencyName)
+                                            .tradingStandardRate(tradingStandardRate)
+                                            .comparedPreviousDay(comparedToThePreviousDay)
+                                            .fluctuationRate(fluctuationRate)
+                                            .buyCash(buyCash)
+                                            .sellCash(sellCash)
+                                            .sendMoney(sendMoney)
+                                            .receiveMoney(receiveMoney)
+                                            .updateAt(updateAt)
+                                            .round(round)
+                                            .build();
+
+            Exchange exchange = Exchange.builder()
+                                        .userId(parameter.getUserId())
+                                        .currencyName(parameter.getCurrencyName())
+                                        .tradingStandardRate(parameter.getTradingStandardRate())
+                                        .comparedPreviousDay(parameter.getComparedPreviousDay())
+                                        .fluctuationRate(parameter.getFluctuationRate())
+                                        .buyCash(parameter.getBuyCash())
+                                        .sellCash(parameter.getSellCash())
+                                        .sendMoney(parameter.getSendMoney())
+                                        .receiveMoney(parameter.getReceiveMoney())
+                                        .updateAt(parameter.getUpdateAt())
+                                        .round(parameter.getRound())
+                                        .build();
+            // DB에 저장
+            exchangeRepository.save(exchange);
+        }
+    }
+
+    // 통화별 리스트 조회 (10개 통화의 10가지 통화정보 조회 - 사용자 조건으로 조회)
+    @Override
+    @Transactional(readOnly = true)
+    public List<ExchangeDto> getExchangeList(String userId) {
+        if (userId == null) {
+            throw new NotFoundUserIdException("사용자 ID를 찾을 수 없습니다.");
+        }
+
+        Optional<List<Exchange>> optionalExchanges
+            = exchangeRepository.findByUserId(userId);
+
+        if (!optionalExchanges.isPresent()) {
+            throw new NotFoundExchangeException("정보를 찾을 수 없습니다.");
+        }
+
+        return ExchangeDto.from(optionalExchanges.get());
+    }
+
+    // 통화별 상세정보 조회 (ex. USD 미국의 10가지 정보 확인 - 사용자 조건으로 조회)
+    @Override
+    @Transactional(readOnly = true)
+    public ExchangeDto getExchangeCurrencyDetail(String userId, String currencyName) {
+        if (userId == null) {
+            throw new NotFoundUserIdException("사용자 ID를 찾을 수 없습니다.");
+        }
+
+        List<Exchange> exchanges =
+            exchangeRepository.findExchangesByUserIdAndCurrencyName(userId, currencyName);
+
+        return ExchangeDto.to(exchanges.get(0));
+    }
+
+    @Override
+    @Transactional
+    public void updateRealTimeExchange(String userId, ExchangeDto exchangedto) {
+        String exchangeString = scraper.scrap();
+        userId = request.getAttribute("userId").toString();
+
+        if (userId == null) {
+            throw new NotFoundUserIdException("사용자 ID를 찾을 수 없습니다.");
+        }
+
+        // 상세환율정보 화면 정보 추가 (10개)
+        for (int i = 0; i < 10; i++) {
+            String[] exchangeParse = exchangeString.split("\n");
+            String[] exchangeData = exchangeParse[i].split(" ");
+
+            String currencyName = exchangeData[0] + " " + exchangeData[1];
+            String tradingStandardRate = exchangeData[2];
+            String comparedToThePreviousDay = exchangeData[3] + " " + exchangeData[4];
+            String fluctuationRate = exchangeData[5];
+            String buyCash = exchangeData[6];
+            String sellCash = exchangeData[7];
+            String sendMoney = exchangeData[8];
+            String receiveMoney = exchangeData[9];
+            String updateAt = exchangeData[10];
+            String round = exchangeData[11] + " " + exchangeData[12];
+
+            ExchangeDto parameter = ExchangeDto.builder()
+                                            .userId(userId)
+                                            .currencyName(currencyName)
+                                            .tradingStandardRate(tradingStandardRate)
+                                            .comparedPreviousDay(comparedToThePreviousDay)
+                                            .fluctuationRate(fluctuationRate)
+                                            .buyCash(buyCash)
+                                            .sellCash(sellCash)
+                                            .sendMoney(sendMoney)
+                                            .receiveMoney(receiveMoney)
+                                            .updateAt(updateAt)
+                                            .round(round)
+                                            .build();
+
+            Exchange exchange = Exchange.builder()
+                                        .userId(parameter.getUserId())
+                                        .currencyName(parameter.getCurrencyName())
+                                        .tradingStandardRate(parameter.getTradingStandardRate())
+                                        .comparedPreviousDay(parameter.getComparedPreviousDay())
+                                        .fluctuationRate(parameter.getFluctuationRate())
+                                        .buyCash(parameter.getBuyCash())
+                                        .sellCash(parameter.getSellCash())
+                                        .sendMoney(parameter.getSendMoney())
+                                        .receiveMoney(parameter.getReceiveMoney())
+                                        .updateAt(parameter.getUpdateAt())
+                                        .round(parameter.getRound())
+                                        .build();
+
+            // DB에 저장
+            exchangeRepository.save(exchange);
+        }
+    }
+
+    @Override
+    @Transactional
+    public void deleteExchange(String userId) {
+        userId = request.getAttribute("userId").toString();
+        if (userId == null) {
+            throw new NotFoundUserIdException("사용자 ID를 찾을 수 없습니다.");
+        }
+        exchangeRepository.deleteByUserId(userId);
+    }
+
+}


### PR DESCRIPTION
## 👩🏻‍🏫 Motivation (작업내역)
Dto, Entity, Controller, Service 클래스 통해 CRUD 기능을 구현하였습니다.

## 🔑 Key Changes (작업 상세내용)
* Controller
1. 실시간 환율 정보를 DB에 저장
2. 메인화면 환율 창에서 환율 정보 조회(통화명, 매매기준율, 전일대비, 등락율)
3. 특정 통화의 상세정보 조회
4. 국가별 환율 상세정보 조회
5. 환율정보 업데이트
6. 환율정보 삭제

* Service
1. ExchangeService - 환율정보 서비스 (10가지 정보)

##
환율 서비스 CRUD 기능을 구현했습니다. 
환율 서비스의 필드값들은 메인 페이지에서 보여지는 4가지 환율 정보와
상세페이지에서 확인할 수 있는 환율 정보(10가지 정보)로 구성했습니다.
그래서 총 두 개의 테이블로 구성이 되어있으며 현재는 Exchange 하나만 올려놓았습니다.

**참고**
◇ 테이블은 2개로 구성
Exchange : 10가지 환율 정보 
(통화명, 매매기준율, 전일대비, 등락율, 현찰 살 때, 현찰 팔 때, 송금 보낼 때, 송금 받을 때, 업데이트 날짜, 고시회차)

PartialExchange : 4가지 환율 정보
(통화명, 매매기준율, 전일대비, 등락율)

## 🙏🏻 To Reviewers (리뷰내용 작성)


◇ Controller 코드 중에 partial로 시작해서 네이밍된 함수들이 있는데 해당 함수들에 관련된 내용은
추후 바로 올리겠습니다. 

