### PR TITLE
Exchange_Feat_Partial-CRUD: #20 - 부분 환율 서비스 CRUD 기능 구현

### DIFF
--- a/src/main/java/com/example/lazier/exchangeModule/dto/PartialExchangeDto.java
+++ b/src/main/java/com/example/lazier/exchangeModule/dto/PartialExchangeDto.java
@@ -1,0 +1,46 @@
+package com.example.lazier.exchangeModule.dto;
+
+import com.example.lazier.exchangeModule.persist.entity.PartialExchange;
+import java.util.ArrayList;
+import java.util.List;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class PartialExchangeDto {
+    private String userId;
+    private String currencyName;            // 통화명
+    private String tradingStandardRate;     // 매매기준율
+    private String comparedPreviousDay;     // 전일대비
+    private String fluctuationRate;         // 등락율
+
+    public static PartialExchangeDto to(PartialExchange partialExchange) {
+        return PartialExchangeDto.builder()
+                                .userId(partialExchange.getUserId())
+                                .currencyName(partialExchange.getCurrencyName())
+                                .tradingStandardRate(partialExchange.getTradingStandardRate())
+                                .comparedPreviousDay(partialExchange.getComparedPreviousDay())
+                                .fluctuationRate(partialExchange.getFluctuationRate())
+                                .build();
+    }
+
+    public static List<PartialExchangeDto> from(List<PartialExchange> partialExchanges) {
+
+        if (partialExchanges == null) {
+            return null;
+        }
+
+        List<PartialExchangeDto> partialExchangeDtoList = new ArrayList<>();
+        for (PartialExchange x : partialExchanges) {
+            partialExchangeDtoList.add(PartialExchangeDto.to(x));
+        }
+
+        return partialExchangeDtoList;
+    }
+
+}

--- a/src/main/java/com/example/lazier/exchangeModule/persist/entity/PartialExchange.java
+++ b/src/main/java/com/example/lazier/exchangeModule/persist/entity/PartialExchange.java
@@ -1,0 +1,29 @@
+package com.example.lazier.exchangeModule.persist.entity;
+
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Entity(name = "PartialExchange")
+@NoArgsConstructor
+@AllArgsConstructor
+@Getter
+@Setter
+@Builder
+public class PartialExchange {
+    @Id
+    @GeneratedValue(strategy = GenerationType.AUTO)
+    private Long id;
+    private String userId;
+    private String currencyName;            // 통화명
+    private String tradingStandardRate;     // 매매기준율
+    private String comparedPreviousDay;     // 전일대비
+    private String fluctuationRate;         // 등락율
+
+}

--- a/src/main/java/com/example/lazier/exchangeModule/persist/repository/PartialExchangeRepository.java
+++ b/src/main/java/com/example/lazier/exchangeModule/persist/repository/PartialExchangeRepository.java
@@ -1,0 +1,20 @@
+package com.example.lazier.exchangeModule.persist.repository;
+
+import com.example.lazier.exchangeModule.persist.entity.PartialExchange;
+import java.util.List;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface PartialExchangeRepository extends JpaRepository<PartialExchange, Long> {
+
+    Optional<List<PartialExchange>> findByUserId(String userId);
+
+    /**
+     * 환율 정보 삭제
+     */
+    void deleteByUserId(String userId);
+
+}

--- a/src/main/java/com/example/lazier/exchangeModule/scraper/ExchangeScraper.java
+++ b/src/main/java/com/example/lazier/exchangeModule/scraper/ExchangeScraper.java
@@ -1,0 +1,64 @@
+package com.example.lazier.exchangeModule.scraper;
+
+import java.io.IOException;
+import org.jsoup.Jsoup;
+import org.jsoup.nodes.Document;
+import org.jsoup.select.Elements;
+import org.springframework.stereotype.Component;
+
+@Component
+public class ExchangeScraper implements Scraper {
+
+    @Override
+    public String scrap() {
+
+        // 한국무역협회 실시간 환율정보에서 데이터 받아오기
+        StringBuffer response = new StringBuffer();
+
+        try {
+            String connUrl = "https://www.kita.net/cmmrcInfo/ehgtGnrlzInfo/rltmEhgt.do";
+            Document document = Jsoup.connect(connUrl).get();
+            for (int i = 0; i < 10; i++) {
+                Elements elem = document.select(
+                    "#contents > div.boardArea > div.tableSt.st4.alc > table > tbody > "
+                        + "tr:nth-child(" + (i + 1) + ")");
+
+                Elements elem2 = document.select(
+                    "#contents > div.boardArea > div.titArea2 > div.exInfo");
+
+                String[] str = elem.text().split("\n");
+                String[] exInfo = str[0].split(" ");
+
+                String[] str2 = elem2.text().split("\n");
+                String[] exInfo2 = str2[0].split(" ");
+
+                String currencyName = exInfo[0] + " " + exInfo[1];                  // 통화명
+                String tradingStandardRate = exInfo[2];                             // 등락율
+                String comparedToThePreviousDay = exInfo[3] + " " + exInfo[4];      // 전일대비
+                String fluctuationRate = exInfo[5];                                 // 등락율
+                String buyCash = exInfo[6];                                         // 현재 살 때
+                String sellCash = exInfo[7];
+                String sendMoney = exInfo[8];
+                String receiveMoney = exInfo[9];
+
+                String updateAt = exInfo2[0];
+                String round = "KB국민은행 " + exInfo2[1];
+
+                Thread.sleep(200);
+
+                response.append(currencyName + " " + tradingStandardRate + " "
+                    + comparedToThePreviousDay + " " + fluctuationRate + " " + buyCash +
+                    " " + sellCash + " " + sendMoney + " " + receiveMoney +
+                    " " + updateAt +  " " + round + "\n");
+            }
+
+        } catch (IOException e) {
+            e.printStackTrace();
+        } catch (InterruptedException e) {
+            throw new RuntimeException(e);
+        }
+
+        return response.toString();
+    }
+
+}

--- a/src/main/java/com/example/lazier/exchangeModule/service/PartialExchangeService.java
+++ b/src/main/java/com/example/lazier/exchangeModule/service/PartialExchangeService.java
@@ -1,0 +1,28 @@
+package com.example.lazier.exchangeModule.service;
+
+import com.example.lazier.exchangeModule.dto.PartialExchangeDto;
+import java.util.List;
+
+public interface PartialExchangeService {
+
+    /**
+     * 환율정보 추가 (10개 통화의 4가지 정보 포함 -  통화명, 매매기준율, 등락율, 전일대비)
+     */
+    void partialAdd(PartialExchangeDto partialExchangeDto, String userId);
+
+    /**
+     * 환율 정보 조회 (10개 통화의 4가지 정보) - 사용자 조건으로
+     */
+    List<PartialExchangeDto> getExchangePartialInfo(String userId);
+
+    /**
+     * 환율 정보 업데이트 (10개 통화의 4가지 정보) - 사용자 조건으로
+     */
+    void updateRealTimePartialExchange(String userId, PartialExchangeDto partialExchangeDto);
+
+    /**
+     * 환율정보 추가 (10개 통화의 4가지 정보 포함 -  통화명, 매매기준율, 등락율, 전일대비)
+     */
+    void deletePartialExchange(String userId);
+
+}

--- a/src/main/java/com/example/lazier/exchangeModule/service/PartialExchangeServiceImpl.java
+++ b/src/main/java/com/example/lazier/exchangeModule/service/PartialExchangeServiceImpl.java
@@ -1,0 +1,130 @@
+package com.example.lazier.exchangeModule.service;
+
+import com.example.lazier.exchangeModule.dto.PartialExchangeDto;
+import com.example.lazier.exchangeModule.exception.NotFoundExchangeException;
+import com.example.lazier.exchangeModule.exception.NotFoundUserIdException;
+import com.example.lazier.exchangeModule.persist.entity.PartialExchange;
+import com.example.lazier.exchangeModule.persist.repository.PartialExchangeRepository;
+import com.example.lazier.exchangeModule.scraper.ExchangeScraper;
+import java.util.List;
+import java.util.Optional;
+import javax.servlet.http.HttpServletRequest;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@RequiredArgsConstructor
+@Service
+public class PartialExchangeServiceImpl implements PartialExchangeService {
+    private final PartialExchangeRepository partialExchangeRepository;
+
+    private final HttpServletRequest request;
+
+    private final ExchangeScraper scraper;
+
+    @Override
+    public void partialAdd(PartialExchangeDto partialExchangeDto, String userId) {
+        String exchangeString = scraper.scrap();
+
+        // 메인화면 환율 정보 추가 (4개) - 회원가입 후 모듈 선택 or 마이페이지에서 모듈 선택시 적용
+        for (int i = 0; i < 4; i++) {
+            String[] exchangeParse = exchangeString.split("\n");
+            String[] exchangeData = exchangeParse[i].split(" ");
+
+            String currencyName = exchangeData[0] + " " + exchangeData[1];
+            String tradingStandardRate = exchangeData[2];
+            String comparedToThePreviousDay = exchangeData[3] + " " + exchangeData[4];
+            String fluctuationRate = exchangeData[5];
+
+            PartialExchangeDto parameter = PartialExchangeDto.builder()
+                                        .userId(userId)
+                                        .currencyName(currencyName)
+                                        .tradingStandardRate(tradingStandardRate)
+                                        .comparedPreviousDay(comparedToThePreviousDay)
+                                        .fluctuationRate(fluctuationRate)
+                                        .build();
+
+            PartialExchange partialExchange = PartialExchange.builder()
+                                            .userId(parameter.getUserId())
+                                            .currencyName(parameter.getCurrencyName())
+                                            .tradingStandardRate(parameter.getTradingStandardRate())
+                                            .comparedPreviousDay(parameter.getComparedPreviousDay())
+                                            .fluctuationRate(parameter.getFluctuationRate())
+                                            .build();
+
+            partialExchangeRepository.save(partialExchange);
+        }
+    }
+
+    // 메인화면의 환율정보 조회 (10개 통화의 4가지 통화정보 조회 - 사용자 조건으로 조회)
+    @Override
+    public List<PartialExchangeDto> getExchangePartialInfo(String userId) {
+        if (userId == null) {
+            throw new NotFoundUserIdException("사용자 ID를 찾을 수 없습니다.");
+        }
+
+        Optional<List<PartialExchange>> optionalPartialExchanges
+            = partialExchangeRepository.findByUserId(userId);
+
+        if (!optionalPartialExchanges.isPresent()) {
+            throw new NotFoundExchangeException("정보를 찾을 수 없습니다.");
+        }
+
+        return PartialExchangeDto.from(optionalPartialExchanges.get());
+    }
+
+    @Override
+    @Transactional
+    public void updateRealTimePartialExchange(String userId,
+        PartialExchangeDto partialExchangeDto) {
+
+        String exchangeString = scraper.scrap();
+        userId = request.getAttribute("userId").toString();
+
+        if (userId == null) {
+            throw new NotFoundUserIdException("사용자 ID를 찾을 수 없습니다.");
+        }
+
+        deletePartialExchange(userId);
+
+        for (int i = 0; i < 4; i++) {
+            String[] exchangeParse = exchangeString.split("\n");
+            String[] exchangeData = exchangeParse[i].split(" ");
+
+            String currencyName = exchangeData[0] + " " + exchangeData[1];
+            String tradingStandardRate = exchangeData[2];
+            String comparedToThePreviousDay = exchangeData[3] + " " + exchangeData[4];
+            String fluctuationRate = exchangeData[5];
+
+            PartialExchangeDto parameter = PartialExchangeDto.builder()
+                                                    .userId(userId)
+                                                    .currencyName(currencyName)
+                                                    .tradingStandardRate(tradingStandardRate)
+                                                    .comparedPreviousDay(comparedToThePreviousDay)
+                                                    .fluctuationRate(fluctuationRate)
+                                                    .build();
+
+            PartialExchange partialExchange = PartialExchange.builder()
+                                        .userId(parameter.getUserId())
+                                        .currencyName(parameter.getCurrencyName())
+                                        .tradingStandardRate(parameter.getTradingStandardRate())
+                                        .comparedPreviousDay(parameter.getComparedPreviousDay())
+                                        .fluctuationRate(parameter.getFluctuationRate())
+                                        .build();
+
+            partialExchangeRepository.save(partialExchange);
+        }
+    }
+
+    @Override
+    @Transactional
+    public void deletePartialExchange(String userId) {
+        userId = request.getAttribute("userId").toString();
+
+        if (userId == null) {
+            throw new NotFoundUserIdException("사용자 ID를 찾을 수 없습니다.");
+        }
+
+        partialExchangeRepository.deleteByUserId(userId);
+    }
+}


### PR DESCRIPTION

## 👩🏻‍🏫 Motivation (작업내역)
4가지 정보를 포함한 PartialExchange 엔터티를 활용한 CRUD 기능 구현

## 🔑 Key Changes (작업 상세내용)
부분 환율 서비스 CRUD 기능을 구현했습니다. 
10가지 중에서 4가지 환율 정보만 활용하기에 PartialExchange로 네이밍을 했습니다.
부분 환율 서비스의 필드값들은 메인 페이지에서 보여지는 4가지 환율 정보로 구성되어 있습니다.
PartialExchange : 4가지 환율 정보
(통화명, 매매기준율, 전일대비, 등락율)

**참고**
처음 푸쉬 때 올려야 했던 ExchangeScraper(스크래핑 관련 코드)도 이번에 같이 올렸습니다.

## 🙏🏻 To Reviewers (리뷰내용 작성)
이번 환율 서비스는 개발 과정에서 마감일이 불분명하여 푸쉬 및 PR 일정이 늦어지는 바람에 다소 많은 PR을 올리게 되었습니다.
추후 개발하고 있는 주식 서비스 같은 경우 기능 단위별로 분류해서 푸쉬 및 PR을 진행하겠습니다.
코드에 궁금하시거나 문제내용 있을 경우 리뷰해주시면 감사하겠습니다.
